### PR TITLE
Add lineart preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ This library uses inference and models from various authors. If you think you mu
 * [DAT](https://github.com/zhengchen1999/dat)
 * [RealPLKSR|DAT](https://github.com/Phhofm/models)
 
-### Preprocesors
+### Preprocessors
 
 * [LineArt](https://github.com/carolineec/informative-drawings)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Set of auxiliary tools to use with image and video generation libraries. Mainly 
 Each set of tools has its own README where you can find more information on how to use them.
 
 * [Upscalers](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/upscalers/README.md)
-* [Preprocesors](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocesors/README.md)
+* [Preprocessors](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocessors/README.md)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Set of auxiliary tools to use with image and video generation libraries. Mainly 
 Each set of tools has its own README where you can find more information on how to use them.
 
 * [Upscalers](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/upscalers/README.md)
+* [Preprocesors](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocesors/README.md)
 
 ## Installation
 
@@ -53,3 +54,7 @@ This library uses inference and models from various authors. If you think you mu
 * [UltraSharp](https://openmodeldb.info/models/4x-UltraSharp)
 * [DAT](https://github.com/zhengchen1999/dat)
 * [RealPLKSR|DAT](https://github.com/Phhofm/models)
+
+### Preprocesors
+
+* [LineArt](https://github.com/carolineec/informative-drawings)

--- a/setup.py
+++ b/setup.py
@@ -107,9 +107,11 @@ _deps = [
     "requests-mock==1.10.0",
     "python>=3.8.0",
     "torch>=2.3",
-    "torchvision",
     "safetensors>=0.3.1",
     "spandrel",
+    "transformers",
+    "kornia",
+    "timm",
 ]
 
 # this is a lookup table with items like:
@@ -183,7 +185,7 @@ class DepsTableUpdateCommand(Command):
 extras = {}
 extras["quality"] = deps_list("urllib3", "isort", "ruff")
 extras["test"] = deps_list("pytest", "pytest-timeout", "pytest-xdist", "requests-mock")
-extras["torch"] = deps_list("torch", "torchvision")
+extras["torch"] = deps_list("torch")
 
 extras["dev"] = extras["quality"] + extras["test"] + extras["torch"]
 
@@ -193,6 +195,10 @@ install_requires = [
     deps["safetensors"],
     deps["Pillow"],
     deps["spandrel"],
+    deps["transformers"],
+    deps["kornia"],
+    deps["timm"],
+    deps["opencv-python-headless"],
 ]
 
 version_range_max = max(sys.version_info[1], 10) + 1

--- a/src/image_gen_aux/__init__.py
+++ b/src/image_gen_aux/__init__.py
@@ -26,6 +26,7 @@ from .utils import IMAGE_AUX_SLOW_IMPORT, OptionalDependencyNotAvailable, _LazyM
 
 _import_structure = {
     "upscalers": [],
+    "preprocessors": [],
     "utils": [
         "OptionalDependencyNotAvailable",
         "is_torch_available",
@@ -42,6 +43,8 @@ except OptionalDependencyNotAvailable:
 else:
     _import_structure["upscalers"].extend(["UpscaleWithModel"])
 
+    _import_structure["preprocessors"].extend(["LineArtPreprocessor"])
+
 if TYPE_CHECKING or IMAGE_AUX_SLOW_IMPORT:
     try:
         if not is_torch_available():
@@ -49,9 +52,8 @@ if TYPE_CHECKING or IMAGE_AUX_SLOW_IMPORT:
     except OptionalDependencyNotAvailable:
         ...
     else:
-        from .upscalers import (
-            UpscaleWithModel,
-        )
+        from .preprocessors import LineArtPreprocessor
+        from .upscalers import UpscaleWithModel
 else:
     import sys
 

--- a/src/image_gen_aux/image_processor.py
+++ b/src/image_gen_aux/image_processor.py
@@ -141,6 +141,17 @@ class ImageMixin:
         return pil_images
 
     def scale_image(self, image: torch.Tensor, scale: float, mutiple_factor: int = 8) -> torch.Tensor:
+        """
+        Scales an image while maintaining aspect ratio and ensuring dimensions are multiples of `multiple_factor`.
+
+        Args:
+            image (torch.Tensor): The input image tensor of shape (batch, channels, height, width).
+            scale (float): The scaling factor to apply to the image dimensions.
+            multiple_factor (int, optional): The factor by which the new dimensions should be divisible. Defaults to 8.
+
+        Returns:
+            torch.Tensor: The scaled image tensor.
+        """
         _batch, _channels, height, width = image.shape
 
         # Calculate new dimensions while maintaining aspect ratio

--- a/src/image_gen_aux/image_processor.py
+++ b/src/image_gen_aux/image_processor.py
@@ -139,3 +139,21 @@ class ImageMixin:
             pil_images = [Image.fromarray(image) for image in images]
 
         return pil_images
+
+    def scale_image(self, image: torch.Tensor, scale: float, mutiple_factor: int = 8) -> torch.Tensor:
+        _batch, _channels, height, width = image.shape
+
+        # Calculate new dimensions while maintaining aspect ratio
+        new_height = int(height * scale)
+        new_width = int(width * scale)
+
+        # Ensure new dimensions are multiples of mutiple_factor
+        new_height = (new_height // mutiple_factor) * mutiple_factor
+        new_width = (new_width // mutiple_factor) * mutiple_factor
+
+        # Resize the image using the calculated dimensions
+        resized_image = torch.nn.functional.interpolate(
+            image, size=(new_height, new_width), mode="bilinear", align_corners=False
+        )
+
+        return resized_image

--- a/src/image_gen_aux/image_processor.py
+++ b/src/image_gen_aux/image_processor.py
@@ -33,17 +33,26 @@ class ImageMixin:
     - Convert a NumPy image or a batch of images to a PIL image.
     """
 
-    def convert_image_to_tensor(self, image: Union[PIL.Image.Image, np.ndarray]) -> torch.Tensor:
+    def convert_image_to_tensor(
+        self, image: Union[PIL.Image.Image, np.ndarray, List[PIL.Image.Image]]
+    ) -> torch.Tensor:
         """
         Convert a PIL image or a NumPy array to a PyTorch tensor.
 
         Args:
-            image (Union[PIL.Image.Image, np.ndarray]): The input image, either as a PIL image or a NumPy array.
+            image (Union[PIL.Image.Image, np.ndarray]): The input image, either as a PIL image, a NumPy array or a list of
+                PIL images.
 
         Returns:
             torch.Tensor: The converted image as a PyTorch tensor.
         """
-        if isinstance(image, PIL.Image.Image):
+        if isinstance(image, (PIL.Image.Image, list)):
+            # We expect that if it is a list, it only should contain pillow images
+            if isinstance(image, list):
+                for single_image in image:
+                    if not isinstance(single_image, PIL.Image.Image):
+                        raise ValueError("All images in the list must be Pillow images.")
+
             image = self.pil_to_numpy(image)
 
         return self.numpy_to_pt(image)

--- a/src/image_gen_aux/image_processor.py
+++ b/src/image_gen_aux/image_processor.py
@@ -145,9 +145,9 @@ class ImageMixin:
         Scales an image while maintaining aspect ratio and ensuring dimensions are multiples of `multiple_factor`.
 
         Args:
-            image (torch.Tensor): The input image tensor of shape (batch, channels, height, width).
-            scale (float): The scaling factor to apply to the image dimensions.
-            multiple_factor (int, optional): The factor by which the new dimensions should be divisible. Defaults to 8.
+            image (`torch.Tensor`): The input image tensor of shape (batch, channels, height, width).
+            scale (`float`): The scaling factor applied to the image dimensions.
+            multiple_factor (`int`, *optional*, defaults to 8): The factor by which the new dimensions should be divisible.
 
         Returns:
             torch.Tensor: The scaled image tensor.

--- a/src/image_gen_aux/image_processor.py
+++ b/src/image_gen_aux/image_processor.py
@@ -150,7 +150,7 @@ class ImageMixin:
             multiple_factor (`int`, *optional*, defaults to 8): The factor by which the new dimensions should be divisible.
 
         Returns:
-            torch.Tensor: The scaled image tensor.
+            `torch.Tensor`: The scaled image tensor.
         """
         _batch, _channels, height, width = image.shape
 

--- a/src/image_gen_aux/modeling_utils.py
+++ b/src/image_gen_aux/modeling_utils.py
@@ -1,0 +1,63 @@
+import itertools
+from typing import List, Tuple
+
+import torch
+from torch import Tensor
+
+
+def get_parameter_device(parameter: torch.nn.Module) -> torch.device:
+    try:
+        parameters_and_buffers = itertools.chain(parameter.parameters(), parameter.buffers())
+        return next(parameters_and_buffers).device
+    except StopIteration:
+        # For torch.nn.DataParallel compatibility in PyTorch 1.5
+
+        def find_tensor_attributes(module: torch.nn.Module) -> List[Tuple[str, Tensor]]:
+            tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v)]
+            return tuples
+
+        gen = parameter._named_members(get_members_fn=find_tensor_attributes)
+        first_tuple = next(gen)
+        return first_tuple[1].device
+
+
+def get_parameter_dtype(parameter: torch.nn.Module) -> torch.dtype:
+    try:
+        params = tuple(parameter.parameters())
+        if len(params) > 0:
+            return params[0].dtype
+
+        buffers = tuple(parameter.buffers())
+        if len(buffers) > 0:
+            return buffers[0].dtype
+
+    except StopIteration:
+        # For torch.nn.DataParallel compatibility in PyTorch 1.5
+
+        def find_tensor_attributes(module: torch.nn.Module) -> List[Tuple[str, Tensor]]:
+            tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v)]
+            return tuples
+
+        gen = parameter._named_members(get_members_fn=find_tensor_attributes)
+        first_tuple = next(gen)
+        return first_tuple[1].dtype
+
+
+class ModelMixin(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @property
+    def device(self) -> torch.device:
+        """
+        `torch.device`: The device on which the module is (assuming that all the module parameters are on the same
+        device).
+        """
+        return get_parameter_device(self)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """
+        `torch.dtype`: The dtype of the module (assuming that all the module parameters have the same dtype).
+        """
+        return get_parameter_dtype(self)

--- a/src/image_gen_aux/modeling_utils.py
+++ b/src/image_gen_aux/modeling_utils.py
@@ -61,13 +61,13 @@ def get_parameter_dtype(parameter: torch.nn.Module) -> torch.dtype:
 
 class ModelMixin(torch.nn.Module):
     """
-    This mixin class provides convenient properties to access the device and data type
+    Provides convenient properties to access the device and data type
     of a PyTorch module.
 
     By inheriting from this class, your custom PyTorch modules can access these properties
-    without the need for manual retrieval of device and data type information.
+    without manual retrieval of device and data type information.
 
-    **Note:** These properties assume that all parameters and buffers of the module reside
+    These properties assume that all module parameters and buffers reside
     on the same device and have the same data type, respectively.
     """
 

--- a/src/image_gen_aux/modeling_utils.py
+++ b/src/image_gen_aux/modeling_utils.py
@@ -6,12 +6,20 @@ from torch import Tensor
 
 
 def get_parameter_device(parameter: torch.nn.Module) -> torch.device:
+    """
+    Gets the device of a PyTorch module's parameters or buffers.
+
+    Args:
+        parameter (torch.nn.Module): The PyTorch module to get the device from.
+
+    Returns:
+        torch.device: The device of the module's parameters or buffers.
+    """
     try:
         parameters_and_buffers = itertools.chain(parameter.parameters(), parameter.buffers())
         return next(parameters_and_buffers).device
     except StopIteration:
         # For torch.nn.DataParallel compatibility in PyTorch 1.5
-
         def find_tensor_attributes(module: torch.nn.Module) -> List[Tuple[str, Tensor]]:
             tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v)]
             return tuples
@@ -22,6 +30,15 @@ def get_parameter_device(parameter: torch.nn.Module) -> torch.device:
 
 
 def get_parameter_dtype(parameter: torch.nn.Module) -> torch.dtype:
+    """
+    Gets the data type of a PyTorch module's parameters or buffers.
+
+    Args:
+        parameter (torch.nn.Module): The PyTorch module to get the data type from.
+
+    Returns:
+        torch.dtype: The data type of the module's parameters or buffers.
+    """
     try:
         params = tuple(parameter.parameters())
         if len(params) > 0:
@@ -33,7 +50,6 @@ def get_parameter_dtype(parameter: torch.nn.Module) -> torch.dtype:
 
     except StopIteration:
         # For torch.nn.DataParallel compatibility in PyTorch 1.5
-
         def find_tensor_attributes(module: torch.nn.Module) -> List[Tuple[str, Tensor]]:
             tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v)]
             return tuples
@@ -44,6 +60,17 @@ def get_parameter_dtype(parameter: torch.nn.Module) -> torch.dtype:
 
 
 class ModelMixin(torch.nn.Module):
+    """
+    This mixin class provides convenient properties to access the device and data type
+    of a PyTorch module.
+
+    By inheriting from this class, your custom PyTorch modules can access these properties
+    without the need for manual retrieval of device and data type information.
+
+    **Note:** These properties assume that all parameters and buffers of the module reside
+    on the same device and have the same data type, respectively.
+    """
+
     def __init__(self):
         super().__init__()
 

--- a/src/image_gen_aux/modeling_utils.py
+++ b/src/image_gen_aux/modeling_utils.py
@@ -10,10 +10,10 @@ def get_parameter_device(parameter: torch.nn.Module) -> torch.device:
     Gets the device of a PyTorch module's parameters or buffers.
 
     Args:
-        parameter (torch.nn.Module): The PyTorch module to get the device from.
+        parameter (`torch.nn.Module`): The PyTorch module from which to get the device.
 
     Returns:
-        torch.device: The device of the module's parameters or buffers.
+        `torch.device`: The device of the module's parameters or buffers.
     """
     try:
         parameters_and_buffers = itertools.chain(parameter.parameters(), parameter.buffers())

--- a/src/image_gen_aux/modeling_utils.py
+++ b/src/image_gen_aux/modeling_utils.py
@@ -34,10 +34,10 @@ def get_parameter_dtype(parameter: torch.nn.Module) -> torch.dtype:
     Gets the data type of a PyTorch module's parameters or buffers.
 
     Args:
-        parameter (torch.nn.Module): The PyTorch module to get the data type from.
+        parameter (`torch.nn.Module`): The PyTorch module from which to get the data type.
 
     Returns:
-        torch.dtype: The data type of the module's parameters or buffers.
+        `torch.dtype`: The data type of the module's parameters or buffers.
     """
     try:
         params = tuple(parameter.parameters())

--- a/src/image_gen_aux/preprocessors/README.MD
+++ b/src/image_gen_aux/preprocessors/README.MD
@@ -1,10 +1,12 @@
-# PREPROCESSORS
+# Preprocessors
+
+Preprocessors in this context refer to the application of machine learning models to images or groups of images as a preliminary step for other tasks. A common use case is to feed preprocessed images into a controlnet to guide the generation of a diffusion model. Examples of preprocessors include depth maps, normals, and edge detection.
 
 ## Supported preprocessors
 
 This is a list of the currently supported preprocessors.
 
-* [LineArtPreprocessor](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocesors/lineart/README.md)
+* [LineArtPreprocessor](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocessors/lineart/README.md)
 
 ### How to use
 

--- a/src/image_gen_aux/preprocessors/README.MD
+++ b/src/image_gen_aux/preprocessors/README.MD
@@ -21,12 +21,11 @@ image = lineart_preprocessor(input_image)
 image.save("lineart.png")
 ```
 
-To load a model you can use the HuggingFace Hub Repository ID, an url or a local path. You can also load `pickle` checkpoints but
-its not recommended. If the checkpoint has custom imports (high risk!!!) you'll need to set the `weights_only` argument to `False`.
+Use the Hugging Face Hub model id, a URL, or a local path to load a model. You can also load pickle checkpoints, but it's not recommended due to the [vulnerabilities](https://docs.python.org/3/library/pickle.html) of pickled files. Loading [safetensor](https://hf.co/docs/safetensors/index) files is a more secure option.
+
+If the checkpoint has custom imports (high risk!), you'll need to set the `weights_only` argument to `False`.
 
 You can also specify a `filename` and a `subfolder` if needed.
-
-Example:
 
 ```python
 lineart_preprocessor = LineArtPreprocessor.from_pretrained("lllyasviel/Annotators", filename="sk_model.pth", weights_only=False).to("cuda")

--- a/src/image_gen_aux/preprocessors/README.MD
+++ b/src/image_gen_aux/preprocessors/README.MD
@@ -2,7 +2,7 @@
 
 ## Supported preprocessors
 
-This is the list of the currently supported preprocessors
+This is a list of the currently supported preprocessors.
 
 * [LineArtPreprocessor](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocesors/lineart/README.md)
 

--- a/src/image_gen_aux/preprocessors/README.MD
+++ b/src/image_gen_aux/preprocessors/README.MD
@@ -1,0 +1,43 @@
+# PREPROCESSORS
+
+## Supported preprocessors
+
+This is the list of the currently supported preprocessors
+
+* [LineArtPreprocessor](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocesors/lineart/README.md)
+
+### How to use
+
+```python
+from image_gen_aux import LineArtPreprocessor
+from image_gen_aux.utils import load_image
+
+input_image = load_image(
+    "https://huggingface.co/datasets/OzzyGT/testing-resources/resolve/main/simple_upscale/hippowaffle.png"
+)
+
+lineart_preprocessor = LineArtPreprocessor.from_pretrained("OzzyGT/lineart").to("cuda")
+image = lineart_preprocessor(input_image)
+image.save("lineart.png")
+```
+
+To load a model you can use the HuggingFace Hub Repository ID, an url or a local path. You can also load `pickle` checkpoints but
+its not recommended. If the checkpoint has custom imports (high risk!!!) you'll need to set the `weights_only` argument to `False`.
+
+You can also specify a `filename` and a `subfolder` if needed.
+
+Example:
+
+```python
+lineart_preprocessor = LineArtPreprocessor.from_pretrained("lllyasviel/Annotators", filename="sk_model.pth", weights_only=False).to("cuda")
+```
+
+### List of safetensors checkpoints
+
+This is the current list of safetensor checkpoints you can use from the hub.
+
+|Preprocessor|Repository|Author|
+|---|---|---|
+|LineArt|OzzyGT/lineart|[Caroline Chan](https://github.com/carolineec)|
+
+If you own the model and want us to change the repository to your name/organization please open an issue.

--- a/src/image_gen_aux/preprocessors/README.MD
+++ b/src/image_gen_aux/preprocessors/README.MD
@@ -8,7 +8,7 @@ This is a list of the currently supported preprocessors.
 
 * [LineArtPreprocessor](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocessors/lineart/README.md)
 
-### How to use
+## General preprocessor usage
 
 ```python
 from image_gen_aux import LineArtPreprocessor

--- a/src/image_gen_aux/preprocessors/README.MD
+++ b/src/image_gen_aux/preprocessors/README.MD
@@ -33,7 +33,7 @@ lineart_preprocessor = LineArtPreprocessor.from_pretrained("lllyasviel/Annotator
 
 ### List of safetensors checkpoints
 
-This is the current list of safetensor checkpoints you can use from the hub.
+This is the current list of safetensor checkpoints available on the Hub.
 
 |Preprocessor|Repository|Author|
 |---|---|---|

--- a/src/image_gen_aux/preprocessors/__init__.py
+++ b/src/image_gen_aux/preprocessors/__init__.py
@@ -1,0 +1,39 @@
+from typing import TYPE_CHECKING
+
+from ..utils import IMAGE_AUX_SLOW_IMPORT, OptionalDependencyNotAvailable, _LazyModule, is_torch_available
+
+
+_import_structure = {
+    "lineart": [],
+}
+
+
+try:
+    if not (is_torch_available()):
+        raise OptionalDependencyNotAvailable()
+except OptionalDependencyNotAvailable:
+    ...
+else:
+    _import_structure["lineart"] = [
+        "LineArtPreprocessor",
+    ]
+
+if TYPE_CHECKING or IMAGE_AUX_SLOW_IMPORT:
+    try:
+        if not is_torch_available():
+            raise OptionalDependencyNotAvailable()
+    except OptionalDependencyNotAvailable:
+        ...
+    else:
+        from .lineart import (
+            LineArtPreprocessor,
+        )
+else:
+    import sys
+
+    sys.modules[__name__] = _LazyModule(
+        __name__,
+        globals()["__file__"],
+        _import_structure,
+        module_spec=__spec__,
+    )

--- a/src/image_gen_aux/preprocessors/lineart/LICENSE.txt
+++ b/src/image_gen_aux/preprocessors/lineart/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Caroline Chan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/image_gen_aux/preprocessors/lineart/README.MD
+++ b/src/image_gen_aux/preprocessors/lineart/README.MD
@@ -1,0 +1,1 @@
+# LineArt

--- a/src/image_gen_aux/preprocessors/lineart/README.MD
+++ b/src/image_gen_aux/preprocessors/lineart/README.MD
@@ -10,11 +10,6 @@ From the project page [summary](https://carolineec.github.io/informative_drawing
 
 ## Usage
 
-## Additional resources
-
-* [Project page](https://carolineec.github.io/informative_drawings/)
-* [Paper](https://arxiv.org/abs/2203.12691)
-
 ```python
 from image_gen_aux import LineArtPreprocessor
 from image_gen_aux.utils import load_image
@@ -27,3 +22,8 @@ lineart_preprocessor = LineArtPreprocessor.from_pretrained("OzzyGT/lineart").to(
 image = lineart_preprocessor(input_image)
 image.save("lineart.png")
 ```
+
+## Additional resources
+
+* [Project page](https://carolineec.github.io/informative_drawings/)
+* [Paper](https://arxiv.org/abs/2203.12691)

--- a/src/image_gen_aux/preprocessors/lineart/README.MD
+++ b/src/image_gen_aux/preprocessors/lineart/README.MD
@@ -2,20 +2,18 @@
 
 ![Image](https://carolineec.github.io/informative_drawings/images/teaser.png)
 
-## Original Repository
+Line Art is based on the original repository, [Informative Drawings: Learning to generate line drawings that convey geometry and semantics](https://github.com/carolineec/informative-drawings).
 
-[Informative Drawings: Learning to generate line drawings that convey geometry and semantics](https://github.com/carolineec/informative-drawings)
+From the project page [summary](https://carolineec.github.io/informative_drawings/):
 
-## Summmary
+*Our method approaches line drawing generation as an unsupervised image translation problem which uses various losses to assess the information communicated in a line drawing. Our key idea is to view the problem as an encoding through a line drawing and to maximize the quality of this encoding through explicit geometry, semantic, and appearance decoding objectives. This evaluation is performed by deep learning methods which decode depth, semantics, and appearance from line drawings. The aim is for the extracted depth and semantic information to match the scene geometry and semantics of the input photographs.*
 
-Our method approaches line drawing generation as an unsupervised image translation problem which uses various losses to assess the information communicated in a line drawing. Our key idea is to view the problem as an encoding through a line drawing and to maximize the quality of this encoding through explicit geometry, semantic, and appearance decoding objectives. This evaluation is performed by deep learning methods which decode depth, semantics, and appearance from line drawings. The aim is for the extracted depth and semantic information to match the scene geometry and semantics of the input photographs.
+## Usage
 
-## Additional links
+## Additional resources
 
-* [Project Page](https://carolineec.github.io/informative_drawings/)
+* [Project page](https://carolineec.github.io/informative_drawings/)
 * [Paper](https://arxiv.org/abs/2203.12691)
-
-### How to use
 
 ```python
 from image_gen_aux import LineArtPreprocessor

--- a/src/image_gen_aux/preprocessors/lineart/README.MD
+++ b/src/image_gen_aux/preprocessors/lineart/README.MD
@@ -1,1 +1,31 @@
-# LineArt
+# Line Art
+
+![Image](https://carolineec.github.io/informative_drawings/images/teaser.png)
+
+## Original Repository
+
+[Informative Drawings: Learning to generate line drawings that convey geometry and semantics](https://github.com/carolineec/informative-drawings)
+
+## Summmary
+
+Our method approaches line drawing generation as an unsupervised image translation problem which uses various losses to assess the information communicated in a line drawing. Our key idea is to view the problem as an encoding through a line drawing and to maximize the quality of this encoding through explicit geometry, semantic, and appearance decoding objectives. This evaluation is performed by deep learning methods which decode depth, semantics, and appearance from line drawings. The aim is for the extracted depth and semantic information to match the scene geometry and semantics of the input photographs.
+
+## Additional links
+
+* [Project Page](https://carolineec.github.io/informative_drawings/)
+* [Paper](https://arxiv.org/abs/2203.12691)
+
+### How to use
+
+```python
+from image_gen_aux import LineArtPreprocessor
+from image_gen_aux.utils import load_image
+
+input_image = load_image(
+    "https://huggingface.co/datasets/OzzyGT/testing-resources/resolve/main/simple_upscale/hippowaffle.png"
+)
+
+lineart_preprocessor = LineArtPreprocessor.from_pretrained("OzzyGT/lineart").to("cuda")
+image = lineart_preprocessor(input_image)
+image.save("lineart.png")
+```

--- a/src/image_gen_aux/preprocessors/lineart/__init__.py
+++ b/src/image_gen_aux/preprocessors/lineart/__init__.py
@@ -1,0 +1,36 @@
+from typing import TYPE_CHECKING
+
+from ...utils import IMAGE_AUX_SLOW_IMPORT, OptionalDependencyNotAvailable, _LazyModule, is_torch_available
+
+
+_import_structure = {}
+
+try:
+    if not (is_torch_available()):
+        raise OptionalDependencyNotAvailable()
+except OptionalDependencyNotAvailable:
+    ...
+else:
+    _import_structure["lineart_preprocessor"] = [
+        "LineArtPreprocessor",
+    ]
+
+if TYPE_CHECKING or IMAGE_AUX_SLOW_IMPORT:
+    try:
+        if not is_torch_available():
+            raise OptionalDependencyNotAvailable()
+    except OptionalDependencyNotAvailable:
+        ...
+    else:
+        from .lineart_preprocessor import (
+            LineArtPreprocessor,
+        )
+else:
+    import sys
+
+    sys.modules[__name__] = _LazyModule(
+        __name__,
+        globals()["__file__"],
+        _import_structure,
+        module_spec=__spec__,
+    )

--- a/src/image_gen_aux/preprocessors/lineart/lineart_preprocessor.py
+++ b/src/image_gen_aux/preprocessors/lineart/lineart_preprocessor.py
@@ -1,0 +1,80 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from typing import Union
+
+import numpy as np
+import PIL.Image
+import torch
+from safetensors.torch import load_file
+
+from ...image_processor import ImageMixin
+from ...utils import SAFETENSORS_FILE_EXTENSION, get_model_path
+from .model import Generator
+
+
+class LineArtPreprocessor(ImageMixin):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def to(self, device):
+        self.model = self.model.to(device)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_or_path: Union[str, os.PathLike],
+        filename: str = None,
+        subfolder: str = None,
+        weights_only: bool = True,
+    ) -> Generator:
+        model_path = get_model_path(pretrained_model_or_path, filename, subfolder)
+
+        file_extension = os.path.basename(model_path).split(".")[-1]
+        if file_extension == SAFETENSORS_FILE_EXTENSION:
+            state_dict = load_file(model_path, device="cpu")
+        else:
+            state_dict = torch.load(model_path, map_location=torch.device("cpu"), weights_only=weights_only)
+
+        model = Generator()
+        model.load_state_dict(state_dict)
+
+        return cls(model)
+
+    @torch.inference_mode
+    def __call__(
+        self,
+        image: Union[PIL.Image.Image, np.ndarray, torch.Tensor],
+        resolution_scale: float = 1.0,
+        invert: bool = True,
+        return_type: str = "pil",
+    ):
+        if not isinstance(image, torch.Tensor):
+            image = self.convert_image_to_tensor(image)
+
+        input_image = self.scale_image(image, resolution_scale) if resolution_scale != 1.0 else image
+
+        input_image = input_image.to(self.model.device)
+        lineart = self.model(input_image)
+
+        if invert:
+            lineart = 255 - lineart
+
+        if resolution_scale != 1.0:
+            lineart = self.scale_image(lineart, 1 / resolution_scale)
+
+        image = self.post_process_image(lineart, return_type)
+
+        return image

--- a/src/image_gen_aux/preprocessors/lineart/lineart_preprocessor.py
+++ b/src/image_gen_aux/preprocessors/lineart/lineart_preprocessor.py
@@ -28,7 +28,7 @@ from .model import Generator
 class LineArtPreprocessor(Preprocessor, ImageMixin):
     """Preprocessor specifically designed for converting images to line art.
 
-    This class inherits from both `Preprocessor` and `ImageMixin`, please refer to each
+    This class inherits from both `Preprocessor` and `ImageMixin`. Please refer to each
     one to get more information.
     """
 

--- a/src/image_gen_aux/preprocessors/lineart/lineart_preprocessor.py
+++ b/src/image_gen_aux/preprocessors/lineart/lineart_preprocessor.py
@@ -64,17 +64,16 @@ class LineArtPreprocessor(Preprocessor, ImageMixin):
         """Preprocesses an image and generates line art using the pre-trained model.
 
         Args:
-            image (Union[PIL.Image.Image, np.ndarray, torch.Tensor]): Input image in PIL Image,
+            image (`Union[PIL.Image.Image, np.ndarray, torch.Tensor]`): Input image as PIL Image,
                 NumPy array, or PyTorch tensor format.
-            resolution_scale (float, optional): Scale factor for image resolution during
-                preprocessing and post-processing (defaults to 1.0 for no scaling).
-            invert (bool, optional): Inverts the generated image if True (white or black background)
-                Defaults to True.
-            return_type (str, optional): The desired return type, either "pt" for PyTorch tensor, "np" for NumPy array,
-                or "pil" for PIL image. Defaults to "pil" for PIL Image format.
+            resolution_scale (`float`, optional, defaults to 1.0): Scale factor for image resolution during
+                preprocessing and post-processing. Defaults to 1.0 for no scaling.
+            invert (`bool`, *optional*, defaults to True): Inverts the generated image if True (white or black background).
+            return_type (`str`, *optional*, defaults to "pil"): The desired return type, either "pt" for PyTorch tensor, "np" for NumPy array,
+                or "pil" for PIL image.
 
         Returns:
-            Union[PIL.Image.Image, np.ndarray, torch.Tensor]: The generated line art in the
+            `Union[PIL.Image.Image, np.ndarray, torch.Tensor]`: The generated line art in the
                 specified output format.
         """
         if not isinstance(image, torch.Tensor):

--- a/src/image_gen_aux/preprocessors/lineart/lineart_preprocessor.py
+++ b/src/image_gen_aux/preprocessors/lineart/lineart_preprocessor.py
@@ -21,16 +21,16 @@ from safetensors.torch import load_file
 
 from ...image_processor import ImageMixin
 from ...utils import SAFETENSORS_FILE_EXTENSION, get_model_path
+from ..preprocessor import Preprocessor
 from .model import Generator
 
 
-class LineArtPreprocessor(ImageMixin):
-    def __init__(self, model):
-        super().__init__()
-        self.model = model
+class LineArtPreprocessor(Preprocessor, ImageMixin):
+    """Preprocessor specifically designed for converting images to line art.
 
-    def to(self, device):
-        self.model = self.model.to(device)
+    This class inherits from both `Preprocessor` and `ImageMixin`, please refer to each
+    one to get more information.
+    """
 
     @classmethod
     def from_pretrained(
@@ -61,6 +61,22 @@ class LineArtPreprocessor(ImageMixin):
         invert: bool = True,
         return_type: str = "pil",
     ):
+        """Preprocesses an image and generates line art using the pre-trained model.
+
+        Args:
+            image (Union[PIL.Image.Image, np.ndarray, torch.Tensor]): Input image in PIL Image,
+                NumPy array, or PyTorch tensor format.
+            resolution_scale (float, optional): Scale factor for image resolution during
+                preprocessing and post-processing (defaults to 1.0 for no scaling).
+            invert (bool, optional): Inverts the generated image if True (white or black background)
+                Defaults to True.
+            return_type (str, optional): The desired return type, either "pt" for PyTorch tensor, "np" for NumPy array,
+                or "pil" for PIL image. Defaults to "pil" for PIL Image format.
+
+        Returns:
+            Union[PIL.Image.Image, np.ndarray, torch.Tensor]: The generated line art in the
+                specified output format.
+        """
         if not isinstance(image, torch.Tensor):
             image = self.convert_image_to_tensor(image)
 

--- a/src/image_gen_aux/preprocessors/lineart/model.py
+++ b/src/image_gen_aux/preprocessors/lineart/model.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2022 Caroline Chan
+#
+# MIT License
+import torch.nn as nn
+
+from ...modeling_utils import ModelMixin
+
+
+norm_layer = nn.InstanceNorm2d
+
+
+class ResidualBlock(nn.Module):
+    def __init__(self, in_features: int):
+        super(ResidualBlock, self).__init__()
+
+        conv_block = [
+            nn.ReflectionPad2d(1),
+            nn.Conv2d(in_features, in_features, 3),
+            norm_layer(in_features),
+            nn.ReLU(inplace=True),
+            nn.ReflectionPad2d(1),
+            nn.Conv2d(in_features, in_features, 3),
+            norm_layer(in_features),
+        ]
+
+        self.conv_block = nn.Sequential(*conv_block)
+
+    def forward(self, x):
+        return x + self.conv_block(x)
+
+
+class Generator(ModelMixin):
+    def __init__(self, input_nc: int = 3, output_nc: int = 1, n_residual_blocks: int = 3, sigmoid: bool = True):
+        super(Generator, self).__init__()
+
+        # Initial convolution block
+        model0 = [nn.ReflectionPad2d(3), nn.Conv2d(input_nc, 64, 7), norm_layer(64), nn.ReLU(inplace=True)]
+        self.model0 = nn.Sequential(*model0)
+
+        # Downsampling
+        model1 = []
+        in_features = 64
+        out_features = in_features * 2
+        for _ in range(2):
+            model1 += [
+                nn.Conv2d(in_features, out_features, 3, stride=2, padding=1),
+                norm_layer(out_features),
+                nn.ReLU(inplace=True),
+            ]
+            in_features = out_features
+            out_features = in_features * 2
+        self.model1 = nn.Sequential(*model1)
+
+        model2 = []
+        # Residual blocks
+        for _ in range(n_residual_blocks):
+            model2 += [ResidualBlock(in_features)]
+        self.model2 = nn.Sequential(*model2)
+
+        # Upsampling
+        model3 = []
+        out_features = in_features // 2
+        for _ in range(2):
+            model3 += [
+                nn.ConvTranspose2d(in_features, out_features, 3, stride=2, padding=1, output_padding=1),
+                norm_layer(out_features),
+                nn.ReLU(inplace=True),
+            ]
+            in_features = out_features
+            out_features = in_features // 2
+        self.model3 = nn.Sequential(*model3)
+
+        # Output layer
+        model4 = [nn.ReflectionPad2d(3), nn.Conv2d(64, output_nc, 7)]
+        if sigmoid:
+            model4 += [nn.Sigmoid()]
+
+        self.model4 = nn.Sequential(*model4)
+
+    def forward(self, x):
+        out = self.model0(x)
+        out = self.model1(out)
+        out = self.model2(out)
+        out = self.model3(out)
+        out = self.model4(out)
+
+        return out

--- a/src/image_gen_aux/preprocessors/preprocessor.py
+++ b/src/image_gen_aux/preprocessors/preprocessor.py
@@ -59,17 +59,17 @@ class Preprocessor(ABC):
         Preprocesses an image for use with the underlying model.
 
         Args:
-            image (Union[PIL.Image.Image, np.ndarray, torch.Tensor]): The input
-                image in PIL Image format, NumPy array, or PyTorch tensor.
-            resolution_scale (float, optional): A scaling factor to apply to
-                the image resolution. Defaults to 1.0 (no scaling).
-            invert (bool, optional): Whether to invert the image.
-                Defaults to True.
-            return_type (str, optional): The desired return type, either "pt" for PyTorch tensor,
-                "np" for NumPy array, or "pil" for PIL image. Defaults to "pil" for PIL Image format.
+            image (`Union[PIL.Image.Image, np.ndarray, torch.Tensor]`): Input image as PIL Image,
+                NumPy array, or PyTorch tensor format.
+            resolution_scale (`float`, optional, defaults to 1.0): Scale factor for image resolution during
+            resolution_scale (`float`, *optional*, defaults to 1.0): Scale factor for image resolution during
+                preprocessing and post-processing. Defaults to 1.0 for no scaling.
+            invert (`bool`, *optional*, defaults to True): Inverts the generated image if True.
+            return_type (`str`, *optional*, defaults to "pil"): The desired return type, either "pt" for PyTorch tensor,
+                "np" for NumPy array, or "pil" for PIL image.
 
         Returns:
-            Union[PIL.Image.Image, torch.Tensor]: The preprocessed image in the
+            `Union[PIL.Image.Image, torch.Tensor]`: The preprocessed image in the
                 specified format.
         """
         pass

--- a/src/image_gen_aux/preprocessors/preprocessor.py
+++ b/src/image_gen_aux/preprocessors/preprocessor.py
@@ -1,0 +1,75 @@
+from abc import ABC, abstractmethod
+from typing import Union
+
+import numpy as np
+import PIL.Image
+import torch
+
+
+class Preprocessor(ABC):
+    """
+    This abstract base class defines the interface for image preprocessors.
+
+    Subclasses should implement the abstract methods `from_pretrained` and
+    `__call__` to provide specific loading and preprocessing logic for their
+    respective models.
+
+    Args:
+        model (nn.Module): The torch model to be used.
+    """
+
+    def __init__(self, model):
+        self.model = model
+
+    def to(self, device):
+        """
+        Moves the underlying model to the specified device
+        (e.g., CPU or GPU).
+
+        Args:
+            device (torch.device): The target device.
+
+        Returns:
+            Preprocessor: The preprocessor object itself (for method chaining).
+        """
+        self.model = self.model.to(device)
+        return self
+
+    @abstractmethod
+    def from_pretrained(self):
+        """
+        This abstract method defines how the preprocessor loads pre-trained
+        weights or configurations specific to the model it supports. Subclasses
+        must implement this method to handle model-specific loading logic.
+
+        This method might download pre-trained weights from a repository or
+        load them from a local file depending on the model's requirements.
+        """
+        pass
+
+    @abstractmethod
+    def __call__(
+        self,
+        image: Union[PIL.Image.Image, np.ndarray, torch.Tensor],
+        resolution_scale: float = 1.0,
+        invert: bool = True,
+        return_type: str = "pil",
+    ):
+        """
+        Preprocesses an image for use with the underlying model.
+
+        Args:
+            image (Union[PIL.Image.Image, np.ndarray, torch.Tensor]): The input
+                image in PIL Image format, NumPy array, or PyTorch tensor.
+            resolution_scale (float, optional): A scaling factor to apply to
+                the image resolution. Defaults to 1.0 (no scaling).
+            invert (bool, optional): Whether to invert the image.
+                Defaults to True.
+            return_type (str, optional): The desired return type, either "pt" for PyTorch tensor,
+                "np" for NumPy array, or "pil" for PIL image. Defaults to "pil" for PIL Image format.
+
+        Returns:
+            Union[PIL.Image.Image, torch.Tensor]: The preprocessed image in the
+                specified format.
+        """
+        pass

--- a/src/image_gen_aux/preprocessors/preprocessor.py
+++ b/src/image_gen_aux/preprocessors/preprocessor.py
@@ -27,10 +27,10 @@ class Preprocessor(ABC):
         (e.g., CPU or GPU).
 
         Args:
-            device (torch.device): The target device.
+            device (`torch.device`): The target device.
 
         Returns:
-            Preprocessor: The preprocessor object itself (for method chaining).
+            `Preprocessor`: The preprocessor object itself (for method chaining).
         """
         self.model = self.model.to(device)
         return self

--- a/src/image_gen_aux/preprocessors/preprocessor.py
+++ b/src/image_gen_aux/preprocessors/preprocessor.py
@@ -15,7 +15,7 @@ class Preprocessor(ABC):
     respective models.
 
     Args:
-        model (nn.Module): The torch model to be used.
+        model (`nn.Module`): The torch model to use.
     """
 
     def __init__(self, model):

--- a/src/image_gen_aux/utils/__init__.py
+++ b/src/image_gen_aux/utils/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .constants import SAFETENSORS_FILE_EXTENSION
 from .import_utils import IMAGE_AUX_SLOW_IMPORT, OptionalDependencyNotAvailable, _LazyModule, is_torch_available
 from .loading_utils import load_image
 from .model_utils import get_model_path

--- a/src/image_gen_aux/utils/constants.py
+++ b/src/image_gen_aux/utils/constants.py
@@ -1,0 +1,1 @@
+SAFETENSORS_FILE_EXTENSION = "safetensors"


### PR DESCRIPTION
Adds the lineart preprocessor

- [X] Lineart preprocesor for images
- [X] Docstrings
- [X] Documentation
- [X] For videos

## Code

### Single image

```python
from image_gen_aux import LineArtPreprocessor
from image_gen_aux.utils import load_image

lineart_preprocessor = LineArtPreprocessor.from_pretrained("OzzyGT/lineart")
lineart_preprocessor.to("cuda")

input_image = load_image(
    "https://huggingface.co/datasets/OzzyGT/testing-resources/resolve/main/simple_upscale/hippowaffle.png"
)

image = lineart_preprocessor(input_image)[0]
image.save("lineart.png")
```

|original|preprocessed|
|---|---|
|![hippowaffle](https://github.com/user-attachments/assets/8a1a54b6-e4b2-45c3-8fcc-24ddcf74bf2e)|![20240904034104](https://github.com/user-attachments/assets/86140638-30bc-4968-9966-82d989e2aff4)|

### Video

```python
import imageio
import numpy as np

from image_gen_aux import LineArtPreprocessor


reader = imageio.get_reader(
    "https://huggingface.co/datasets/OzzyGT/testing-resources/resolve/main/lineart/movie_chunk.mov"
)

frame_shape = reader.get_data(0).shape
frames = []

for frame in reader:
    normalized_frame = frame.astype(np.float32) / 255.0
    frames.append(normalized_frame)

inputs = np.stack(frames, axis=0)

lineart_preprocessor = LineArtPreprocessor.from_pretrained("OzzyGT/lineart").to("cuda")

image = lineart_preprocessor(inputs, batch_size=10)

writer = imageio.get_writer("lineart_movie_out.mp4", fps=24)
for singe_image in image:
    np_image = np.array(singe_image)
    writer.append_data(np_image)
writer.close()
```

#### Original
https://github.com/user-attachments/assets/985c5d00-cb54-4607-bf5f-fe21f6f12475

#### Preprocessed
https://github.com/user-attachments/assets/37b57ba1-ad10-4bcb-8901-a29aacca0ed6






