### PR TITLE
[preprocessors] Lineart standard preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ This library uses inference and models from various authors. If you think you mu
 
 ### Preprocessors
 
-* [LineArt](https://github.com/carolineec/informative-drawings)
 * [Depth Anything V2](https://depth-anything-v2.github.io)
+* [LineArt](https://github.com/carolineec/informative-drawings)
+* [LineArtStandard](https://github.com/Fannovel16/comfyui_controlnet_aux/blob/main/src/custom_controlnet_aux/lineart_standard/__init__.py)
 * [TEED](https://github.com/xavysp/TEED)
 * [ZoeDepth](https://github.com/isl-org/ZoeDepth)

--- a/src/image_gen_aux/__init__.py
+++ b/src/image_gen_aux/__init__.py
@@ -32,7 +32,7 @@ from .utils import (
 
 _import_structure = {
     "upscalers": [],
-    "preprocessors": [],
+    "preprocessors": ["LineArtStandardPreprocessor"],
     "utils": [
         "OptionalDependencyNotAvailable",
         "is_torch_available",
@@ -49,9 +49,11 @@ except OptionalDependencyNotAvailable:
 else:
     _import_structure["upscalers"].extend(["UpscaleWithModel"])
 
-    _import_structure["preprocessors"].extend(["LineArtPreprocessor", "DepthPreprocessor", "TeedPreprocessor"])
+    _import_structure["preprocessors"].extend(["DepthPreprocessor", "LineArtPreprocessor", "TeedPreprocessor"])
 
 if TYPE_CHECKING or IMAGE_AUX_SLOW_IMPORT:
+    from .preprocessors import LineArtStandardPreprocessor
+
     try:
         if not is_torch_available():
             raise OptionalDependencyNotAvailable()

--- a/src/image_gen_aux/preprocessors/README.md
+++ b/src/image_gen_aux/preprocessors/README.md
@@ -6,8 +6,9 @@ Preprocessors in this context refer to the application of machine learning model
 
 This is a list of the currently supported preprocessors.
 
-* [LineArtPreprocessor](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocessors/lineart/README.md)
 * [DepthPreprocessor](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocessors/depth/README.md)
+* [LineArtPreprocessor](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocessors/lineart/README.md)
+* [LineArtStandardPreprocessor](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocessors/lineart_standard/README.md)
 * [TeedPreprocessor](https://github.com/asomoza/image_gen_aux/blob/main/src/image_gen_aux/preprocessors/teed/README.md)
 
 ## General preprocessor usage

--- a/src/image_gen_aux/preprocessors/__init__.py
+++ b/src/image_gen_aux/preprocessors/__init__.py
@@ -13,6 +13,7 @@ _import_structure = {
     "lineart": [],
     "depth": [],
     "teed": [],
+    "lineart_standard": ["LineArtStandardPreprocessor"],
 }
 
 
@@ -36,6 +37,8 @@ else:
     ]
 
 if TYPE_CHECKING or IMAGE_AUX_SLOW_IMPORT:
+    from .lineart_standard import LineArtStandardPreprocessor
+
     try:
         if not is_torch_available():
             raise OptionalDependencyNotAvailable()

--- a/src/image_gen_aux/preprocessors/lineart_standard/README.md
+++ b/src/image_gen_aux/preprocessors/lineart_standard/README.md
@@ -1,0 +1,23 @@
+# Line Art Standard
+
+Line Art Standard was copied from the [comfyui_controlnet_aux](https://github.com/Fannovel16/comfyui_controlnet_aux) repository.
+This preprocessor applies a Gaussian blur to the image to reduce noise and detail, then calculates the intensity difference between the blurred and original images to highlight edges.
+
+## Usage
+
+```python
+from image_gen_aux import LineArtStandardPreprocessor
+from image_gen_aux.utils import load_image
+
+input_image = load_image(
+    "https://huggingface.co/datasets/OzzyGT/testing-resources/resolve/main/simple_upscale/hippowaffle.png"
+)
+
+lineart_standard_preprocessor = LineArtStandardPreprocessor()
+image = lineart_standard_preprocessor(input_image)[0]
+image.save("lineart_standard.png")
+```
+
+## Additional resources
+
+* [Original implementation](https://github.com/Fannovel16/comfyui_controlnet_aux/blob/main/src/custom_controlnet_aux/lineart_standard/__init__.py)

--- a/src/image_gen_aux/preprocessors/lineart_standard/__init__.py
+++ b/src/image_gen_aux/preprocessors/lineart_standard/__init__.py
@@ -1,0 +1,36 @@
+from typing import TYPE_CHECKING
+
+from ...utils import IMAGE_AUX_SLOW_IMPORT, OptionalDependencyNotAvailable, _LazyModule, is_torch_available
+
+
+_import_structure = {}
+
+try:
+    if not (is_torch_available()):
+        raise OptionalDependencyNotAvailable()
+except OptionalDependencyNotAvailable:
+    ...
+else:
+    _import_structure["lineart_standard_preprocessor"] = [
+        "LineArtStandardPreprocessor",
+    ]
+
+if TYPE_CHECKING or IMAGE_AUX_SLOW_IMPORT:
+    try:
+        if not is_torch_available():
+            raise OptionalDependencyNotAvailable()
+    except OptionalDependencyNotAvailable:
+        ...
+    else:
+        from .lineart_standard_preprocessor import (
+            LineArtStandardPreprocessor,
+        )
+else:
+    import sys
+
+    sys.modules[__name__] = _LazyModule(
+        __name__,
+        globals()["__file__"],
+        _import_structure,
+        module_spec=__spec__,
+    )

--- a/src/image_gen_aux/preprocessors/lineart_standard/lineart_standard_preprocessor.py
+++ b/src/image_gen_aux/preprocessors/lineart_standard/lineart_standard_preprocessor.py
@@ -1,0 +1,80 @@
+from typing import List, Union
+
+import cv2
+import numpy as np
+import PIL.Image
+
+from ...image_processor import ImageMixin
+
+
+class LineArtStandardPreprocessor(ImageMixin):
+    """Preprocessor specifically designed for converting images to line art standard.
+
+    This class inherits from both `Preprocessor` and `ImageMixin`. Please refer to each
+    one to get more information.
+    """
+
+    def __call__(
+        self,
+        image: Union[PIL.Image.Image, np.ndarray, List[PIL.Image.Image]],
+        resolution_scale: float = 1.0,
+        invert: bool = False,
+        guassian_sigma=6.0,
+        intensity_threshold=8,
+        return_type: str = "pil",
+    ):
+        """Preprocesses an image and generates line art (standard) using the opencv.
+
+        Args:
+            image (`Union[PIL.Image.Image, np.ndarray, torch.Tensor, List[PIL.Image.Image]]`): Input image as PIL Image,
+                NumPy array, PyTorch tensor format or a list of PIL Images
+            resolution_scale (`float`, optional, defaults to 1.0): Scale factor for image resolution during
+                preprocessing and post-processing. Defaults to 1.0 for no scaling.
+            invert (`bool`, *optional*, defaults to True): Inverts the generated image if True (white or black background).
+            guassian_sigma (float, optional): Sigma value for Gaussian blur. Defaults to 6.0.
+            intensity_threshold (int, optional): Threshold for intensity clipping. Defaults to 8.
+            return_type (`str`, *optional*, defaults to "pil"): The desired return type, either "pt" for PyTorch tensor, "np" for NumPy array,
+                or "pil" for PIL image.
+
+        Returns:
+            `Union[PIL.Image.Image, np.ndarray, torch.Tensor]`: The generated line art (standard) in the
+                specified output format.
+        """
+        if not isinstance(image, np.ndarray):
+            image = np.array(image).astype(np.float32)
+
+        # check if image has batch, if not, add it
+        if len(image.shape) == 3:
+            image = image[None, ...]
+
+        image = self.resize_numpy_image(image, resolution_scale) if resolution_scale != 1.0 else image
+
+        batch_size, height, width, _channels = image.shape
+        processed_images = np.empty((batch_size, height, width), dtype=np.uint8)
+
+        # since we're using just cv2, we can't do batch processing
+        for i in range(batch_size):
+            gaussian = cv2.GaussianBlur(image[i], (0, 0), guassian_sigma)
+            intensity = np.min(gaussian - image[i], axis=2).clip(0, 255)
+            intensity /= max(16, np.median(intensity[intensity > intensity_threshold]))
+            intensity *= 127
+            edges = intensity.clip(0, 255).astype(np.uint8)
+
+            processed_images[i] = edges
+
+        if invert:
+            processed_images = 255 - processed_images
+
+        processed_images = processed_images[..., None]
+
+        if resolution_scale != 1.0:
+            processed_images = self.resize_numpy_image(processed_images, 1 / resolution_scale)
+            processed_images = processed_images[..., None]  # cv2 resize removes the channel dimension if grayscale
+
+        if return_type == "np":
+            return processed_images
+
+        processed_images = np.transpose(processed_images, (0, 3, 1, 2))
+        processed_images = [PIL.Image.fromarray(image.squeeze(), mode="L") for image in processed_images]
+
+        return processed_images

--- a/src/image_gen_aux/preprocessors/teed/teed_preprocessor.py
+++ b/src/image_gen_aux/preprocessors/teed/teed_preprocessor.py
@@ -101,11 +101,13 @@ class TeedPreprocessor(Preprocessor, ImageMixin):
                 edge = 1 - edge
 
             processed_images.append(edge.unsqueeze(0).cpu())
-
         teed = torch.cat(processed_images, dim=0)
 
         # add missing channel
         teed = teed.unsqueeze(1)
+
+        if resolution_scale != 1.0:
+            teed = self.scale_image(teed, 1 / resolution_scale)
 
         image = self.post_process_image(teed, return_type)
 


### PR DESCRIPTION
Add Lineart standard preprocessor (edge detection)

## Code

### Single image

```python
from image_gen_aux import LineArtStandardPreprocessor
from image_gen_aux.utils import load_image

lineart_standard_preprocessor = LineArtStandardPreprocessor()

input_image = load_image(
    "https://huggingface.co/datasets/OzzyGT/testing-resources/resolve/main/teed/20240922043215.png"
)


image = lineart_standard_preprocessor(input_image)[0]
image.save("lineart_standard.png")
```

|source|preprocessed|
|---|---|
|![20240922043215](https://github.com/user-attachments/assets/4e73bfd3-7e35-47d1-af4f-f69b8c71e747)|![20240925061635](https://github.com/user-attachments/assets/586d1c9f-c0b1-4249-a6b6-1b4c515b2459)|

### Video

```python
import imageio
import numpy as np

from image_gen_aux import LineArtStandardPreprocessor


reader = imageio.get_reader(
    "https://huggingface.co/datasets/OzzyGT/testing-resources/resolve/main/lineart/movie_chunk.mov"
)

frame_shape = reader.get_data(0).shape
frames = []

for frame in reader:
    normalized_frame = frame.astype(np.float32)
    frames.append(normalized_frame)


inputs = np.stack(frames, axis=0)

lineart_standard_preprocessor = LineArtStandardPreprocessor()

iimage = lineart_standard_preprocessor(inputs)

writer = imageio.get_writer("lineart_standard_movie_out.mp4", fps=24)
for singe_image in image:
    np_image = np.array(singe_image)
    writer.append_data(np_image)
writer.close()
```

https://github.com/user-attachments/assets/4f101a45-8c57-4d80-86b1-7a4e3d8ed44d
